### PR TITLE
Potential fix for code scanning alert no. 50: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/third_party/java/proguard/proguard6.2.2/src/proguard/io/DirectoryWriter.java
+++ b/third_party/java/proguard/proguard6.2.2/src/proguard/io/DirectoryWriter.java
@@ -23,7 +23,8 @@ package proguard.io;
 import proguard.classfile.ClassConstants;
 
 import java.io.*;
-
+import java.nio.file.Path;
+import java.nio.file.Paths;
 /**
  * This DataEntryWriter writes data entries to individual files in a given
  * directory.
@@ -106,13 +107,24 @@ public class DirectoryWriter implements DataEntryWriter
     /**
      * Returns the file for the given data entry.
      */
-    private File getFile(DataEntry dataEntry)
+    private File getFile(DataEntry dataEntry) throws IOException
     {
         // Use the specified file, or construct a new file.
-        return isFile ?
-            baseFile :
-            new File(baseFile,
-                     dataEntry.getName().replace(ClassConstants.PACKAGE_SEPARATOR,
-                                                 File.separatorChar));
+        if (isFile)
+        {
+            return baseFile;
+        }
+        File outFile = new File(baseFile,
+                                dataEntry.getName().replace(ClassConstants.PACKAGE_SEPARATOR,
+                                                            File.separatorChar));
+        // Enforce Zip Slip check
+        File canonicalBase = baseFile.getCanonicalFile();
+        File canonicalOut = outFile.getCanonicalFile();
+        Path basePath = canonicalBase.toPath();
+        Path outPath = canonicalOut.toPath();
+        if (!outPath.startsWith(basePath)) {
+            throw new IOException("Entry is outside the target dir: " + dataEntry.getName());
+        }
+        return outFile;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/jeffbrown7816-collab/bazel/security/code-scanning/50](https://github.com/jeffbrown7816-collab/bazel/security/code-scanning/50)

To fix the vulnerability, we need to ensure file/directory paths constructed using ZIP entry names remain within the intended base directory (`baseFile`). This is best done in the location where `getFile(DataEntry)` translates the entry name into a `File` -- i.e., in the `DirectoryWriter` class.

The standard approach is:
- When constructing a file path using `baseFile` and the entry name, normalize the resulting path (`File#getCanonicalFile` or `Path#normalize`).
- Check that the normalized path starts with the canonical base directory path; otherwise, reject the entry.

Thus, we should:
- Update the `getFile(DataEntry dataEntry)` method in `DirectoryWriter` so that, when constructing the output path for a data entry, it:
    1. Constructs the File as usual.
    2. Resolves it to its canonical path via `getCanonicalFile()`.
    3. Compares the base directory's canonical path to the output file's canonical path using `startsWith`.
    4. Throws an exception if a directory traversal attempt is detected.

A static method could be added to handle this validation. We'll need to import `java.nio.file.Path` and potentially `java.nio.file.Paths`, but these are core JDK classes.

We do not need to change the `ZipFileDataEntry` itself—the vulnerability is in how its name is used in `DirectoryWriter`. All changes are in `DirectoryWriter.java` inside the shown snippets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
